### PR TITLE
Added color selection to preferences

### DIFF
--- a/plugin/src/winterwell/markdown/editors/MDScanner.java
+++ b/plugin/src/winterwell/markdown/editors/MDScanner.java
@@ -5,6 +5,8 @@
  */
 package winterwell.markdown.editors;
 
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceConverter;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.TextAttribute;
 import org.eclipse.jface.text.rules.IRule;
@@ -20,6 +22,9 @@ import org.eclipse.jface.text.rules.WhitespaceRule;
 import org.eclipse.jface.text.rules.WordRule;
 import org.eclipse.swt.SWT;
 
+import winterwell.markdown.Activator;
+import winterwell.markdown.preferences.MarkdownPreferencePage;
+
 /**
  * 
  *
@@ -28,10 +33,11 @@ import org.eclipse.swt.SWT;
 public class MDScanner extends RuleBasedScanner {
 	ColorManager cm;
     public MDScanner(ColorManager cm) {
-    	this.cm = cm;      
-    	Token heading = new Token(new TextAttribute(cm.getColor(MDColorConstants.HEADER), null, SWT.BOLD));
-        Token comment = new Token(new TextAttribute(cm.getColor(MDColorConstants.COMMENT)));
-        Token emphasis = new Token(new TextAttribute(cm.getColor(MDColorConstants.DEFAULT), null, SWT.ITALIC));
+    	this.cm = cm;
+    	IPreferenceStore pStore = Activator.getDefault().getPreferenceStore();
+    	Token heading = new Token(new TextAttribute(cm.getColor(PreferenceConverter.getColor(pStore, MarkdownPreferencePage.PREF_HEADER)), null, SWT.BOLD));
+    	Token comment = new Token(new TextAttribute(cm.getColor(PreferenceConverter.getColor(pStore, MarkdownPreferencePage.PREF_COMMENT))));
+    	Token emphasis = new Token(new TextAttribute(cm.getColor(PreferenceConverter.getColor(pStore, MarkdownPreferencePage.PREF_DEFUALT)), null, SWT.ITALIC));
         setRules(new IRule[] {           
            new HeaderRule(heading),
            new EmphasisRule("_", emphasis),

--- a/plugin/src/winterwell/markdown/preferences/MarkdownPreferencePage.java
+++ b/plugin/src/winterwell/markdown/preferences/MarkdownPreferencePage.java
@@ -3,6 +3,7 @@ package winterwell.markdown.preferences;
 import org.eclipse.jface.preference.*;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
@@ -42,6 +43,14 @@ public class MarkdownPreferencePage
 	public static final String PREF_MARKDOWN_COMMAND = "Pref_Markdown_Command";
 	private static final String MARKDOWNJ = "(use built-in MarkdownJ converter)";
 	
+
+	public static final String PREF_DEFUALT = "Pref_Default";
+	public static final String PREF_COMMENT = "Pref_Comment";
+	public static final String PREF_HEADER = "Pref_Header";
+	private static final RGB DEF_DEFAULT = new RGB(0, 0, 0);
+	private static final RGB DEF_COMMENT = new RGB(128, 0, 0);
+	private static final RGB DEF_HEADER = new RGB(0, 0, 128);
+	
 	public MarkdownPreferencePage() {
 		super(GRID);
 		IPreferenceStore pStore = Activator.getDefault().getPreferenceStore();
@@ -51,6 +60,11 @@ public class MarkdownPreferencePage
 		pStore.setDefault(PREF_TASK_TAGS_DEFINED, "TODO,FIXME,??");
 		pStore.setDefault(PREF_MARKDOWN_COMMAND, MARKDOWNJ);
 		pStore.setDefault(PREF_SECTION_NUMBERS, true);
+		
+		PreferenceConverter.setDefault(pStore, PREF_DEFUALT, DEF_DEFAULT);
+		PreferenceConverter.setDefault(pStore, PREF_COMMENT, DEF_COMMENT);
+		PreferenceConverter.setDefault(pStore, PREF_HEADER, DEF_HEADER);
+		
 		setPreferenceStore(pStore);
 		setDescription("Settings for the Markdown text editor. See also the general text editor preferences.");
 	}
@@ -98,6 +112,16 @@ public class MarkdownPreferencePage
 				"This should take in a file and output to std-out.\n" +
 				"Leave blank to use the built-in Java converter.", getFieldEditorParent());		
 		addField(cmd);
+		
+		ColorFieldEditor def = new ColorFieldEditor(PREF_DEFUALT, "Default text", getFieldEditorParent());
+		addField(def);
+		
+		ColorFieldEditor com = new ColorFieldEditor(PREF_COMMENT, "Comment", getFieldEditorParent());
+		addField(com);
+		
+		ColorFieldEditor head = new ColorFieldEditor(PREF_HEADER, "Header", getFieldEditorParent());
+		addField(head);
+		
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
Now default (used for highlights), comment and header colors can be set.

I had the same problem as https://github.com/eclipse-color-theme/eclipse-color-theme/issues/114 and https://github.com/winterstein/Eclipse-Markdown-Editor-Plugin/issues/7
