### PR TITLE
Fixed and Improved Multi-Markdown metadata support

### DIFF
--- a/plugin/src/winterwell/markdown/pagemodel/MarkdownPage.java
+++ b/plugin/src/winterwell/markdown/pagemodel/MarkdownPage.java
@@ -270,28 +270,59 @@ public class MarkdownPage {
 			// ends with the first whitespace only line. The metadata is
 			// stripped from the
 			// document before it is passed on to the syntax parser.
-			String data = "";
-			String tag = "";
-			for (; lineNum < lines.size(); lineNum++) {
+			
+			//
+			// Check if the Metdatas are valid
+			//
+			boolean validMetadata = true;
+			for (lineNum = 0; lineNum < lines.size(); lineNum++) {
 				String line = lines.get(lineNum);
 				if (Utils.isBlank(line)) {
 					break;
 				}
 				Matcher m = multiMarkdownTag.matcher(line);
 				if (!m.find()) {
-					if (lineNum == 0)
+					if (lineNum == 0) {
+						// No MultiMarkdown metadata
+						validMetadata = false;
 						break;
-					// Multi-line tag
-					lineTypes.add(KLineType.META);
-					data += StrUtils.LINEEND + line.trim();
-					multiMarkdownTags.put(tag, data);
-				} else {
-					lineTypes.add(KLineType.META);
-					tag = m.group(0);
-					data = m.group(1).trim();
-					if (m.group(1).endsWith(line))
-						multiMarkdownTags.put(tag, data);
+					} else if (!line.matches("^\\s.*\n")) {
+						// The next line was not intended (ie. it does not start
+						// with a whitespace)
+						validMetadata = false;
+						break;
+					}
 				}
+			}
+			
+			// Valid Metadatas have been found. We need to retrieve these keys/values.
+			if (validMetadata) {
+				String data = "";
+				String tag = "";
+				for (lineNum = 0; lineNum < lines.size(); lineNum++) {
+					String line = lines.get(lineNum);
+					if (Utils.isBlank(line)) {
+						break;
+					}
+					Matcher m = multiMarkdownTag.matcher(line);
+					if (!m.find()) {
+						if (lineNum == 0) {
+							break;
+						}
+						// Multi-line tag
+						lineTypes.add(KLineType.META);
+						data += StrUtils.LINEEND + line.trim();
+						multiMarkdownTags.put(tag, data);
+					} else {
+						lineTypes.add(KLineType.META);
+						tag = m.group(0);
+						data = m.group(1).trim();
+						if (m.group(1).endsWith(line))
+							multiMarkdownTags.put(tag, data);
+					}
+				}
+			} else {
+				lineNum = 0;
 			}
 		}
 		for (; lineNum < lines.size(); lineNum++) {

--- a/plugin/src/winterwell/markdown/pagemodel/MarkdownPage.java
+++ b/plugin/src/winterwell/markdown/pagemodel/MarkdownPage.java
@@ -210,7 +210,7 @@ public class MarkdownPage {
 
 	private boolean multiMarkdownSupport = true;
 	// TODO meta-data, footnotes, tables, link & image attributes
-	private static Pattern multiMarkdownTag = Pattern.compile("(.+):(.*)");
+	private static Pattern multiMarkdownTag = Pattern.compile("^([\\w].*):(.*)");
 	private Map<String, String> multiMarkdownTags = new HashMap<String, String>();
 	
 	// Regular expression for Github support

--- a/plugin/src/winterwell/markdown/pagemodel/MarkdownPage.java
+++ b/plugin/src/winterwell/markdown/pagemodel/MarkdownPage.java
@@ -208,7 +208,6 @@ public class MarkdownPage {
 	private List<KLineType> lineTypes;
 	private Map<Integer,Object> pageObjects = new HashMap<Integer, Object>();
 
-	private boolean multiMarkdownSupport = true;
 	// TODO meta-data, footnotes, tables, link & image attributes
 	private static Pattern multiMarkdownTag = Pattern.compile("^([\\w].*):(.*)");
 	private Map<String, String> multiMarkdownTags = new HashMap<String, String>();
@@ -252,8 +251,12 @@ public class MarkdownPage {
 		// Identify line types		
 		int lineNum = 0;
 
+		// Check if we should support the Multi-Markdown Metadata
+		boolean multiMarkdownMetadataSupport =
+				pStore.getBoolean(MarkdownPreferencePage.PREF_MULTIMARKDOWN_METADATA);
+		
 		// Multi-markdown header
-		if (multiMarkdownSupport) {
+		if (multiMarkdownMetadataSupport) {
 			// The key is the text before the colon, and the data is the text
 			// after the
 			// colon. In the above example, notice that there are two lines of

--- a/plugin/src/winterwell/markdown/preferences/MarkdownPreferencePage.java
+++ b/plugin/src/winterwell/markdown/preferences/MarkdownPreferencePage.java
@@ -50,6 +50,7 @@ public class MarkdownPreferencePage
 	public static final String PREF_CODE_BG = "Pref_Code_Background";
 	
 	public static final String PREF_GITHUB_SYNTAX = "Pref_Github_Syntax";
+	public static final String PREF_MULTIMARKDOWN_METADATA = "Pref_MultiMarkdown_Metadata";
 	
 	private static final RGB DEF_DEFAULT = new RGB(0, 0, 0);
 	private static final RGB DEF_COMMENT = new RGB(128, 0, 0);
@@ -74,6 +75,7 @@ public class MarkdownPreferencePage
 		pStore.setDefault(PREF_MARKDOWN_COMMAND, MARKDOWNJ);
 		pStore.setDefault(PREF_SECTION_NUMBERS, true);
 		pStore.setDefault(PREF_GITHUB_SYNTAX, true);
+		pStore.setDefault(PREF_MULTIMARKDOWN_METADATA, false);
 		
 		PreferenceConverter.setDefault(pStore, PREF_DEFUALT, DEF_DEFAULT);
 		PreferenceConverter.setDefault(pStore, PREF_COMMENT, DEF_COMMENT);
@@ -152,6 +154,12 @@ public class MarkdownPreferencePage
 		// Github Syntax support
 		fd = new BooleanFieldEditor(PREF_GITHUB_SYNTAX,
 				"Support Github Syntax",
+				getFieldEditorParent());
+		addField(fd);
+
+		// Multi-Markdown support
+		fd = new BooleanFieldEditor(PREF_MULTIMARKDOWN_METADATA,
+				"Support Multi-Markdown Metadata",
 				getFieldEditorParent());
 		addField(fd);
 	}


### PR DESCRIPTION
This patchset allows:
- Enable/Disable the parsing of Multi-Markdown metadata. Some document could not want their first lines to be parsed.
- Fixed the regular expression to catch Multi-Markdown metadata key/value. It fixes the issue #21.
- Check the metadata block is valid before parsing it.