### PR TITLE
markdown/pagemodel: Added support for Github code block

### DIFF
--- a/plugin/src/winterwell/markdown/pagemodel/MarkdownPage.java
+++ b/plugin/src/winterwell/markdown/pagemodel/MarkdownPage.java
@@ -246,6 +246,8 @@ public class MarkdownPage {
 		Header currentHeader = dummyTopHeader;		
 		// Identify line types		
 		int lineNum = 0;
+		IPreferenceStore pStore = Activator.getDefault().getPreferenceStore();
+
 		// Multi-markdown header
 		if (multiMarkdownSupport) {
 			// The key is the text before the colon, and the data is the text
@@ -327,6 +329,32 @@ public class MarkdownPage {
 		// Remove dummy header?
 		if (dummyTopHeader.getSubHeaders().size() == 0) {
 			level1Headers.remove(dummyTopHeader);
+		}
+		
+		boolean githubSyntaxSupport =
+				pStore.getBoolean(MarkdownPreferencePage.PREF_GITHUB_SYNTAX);
+		if (githubSyntaxSupport) {
+			/*
+			 * Support Code block
+			 */
+			boolean inCodeBlock = false;
+			for (lineNum = 0; lineNum < lines.size(); lineNum++) {
+				String line = lines.get(lineNum);
+				// Found the start or end of a code block
+				if (line.matches("^```.*\n")) {
+					// We reverse the boolean value
+					inCodeBlock = !inCodeBlock;
+
+					// We force the line to be blank. But we mark it as normal
+					// to prevent to be stripped
+					lines.set(lineNum, "\n");
+					lineTypes.set(lineNum, KLineType.NORMAL);
+					continue;
+				}
+				if (inCodeBlock) {
+					lines.set(lineNum, "    " + line);
+				}
+			}
 		}
 	}
 

--- a/plugin/src/winterwell/markdown/preferences/MarkdownPreferencePage.java
+++ b/plugin/src/winterwell/markdown/preferences/MarkdownPreferencePage.java
@@ -49,6 +49,8 @@ public class MarkdownPreferencePage
 	public static final String PREF_CODE = "Pref_Code";
 	public static final String PREF_CODE_BG = "Pref_Code_Background";
 	
+	public static final String PREF_GITHUB_SYNTAX = "Pref_Github_Syntax";
+	
 	private static final RGB DEF_DEFAULT = new RGB(0, 0, 0);
 	private static final RGB DEF_COMMENT = new RGB(128, 0, 0);
 	private static final RGB DEF_HEADER = new RGB(0, 128, 0);
@@ -71,6 +73,7 @@ public class MarkdownPreferencePage
 		pStore.setDefault(PREF_TASK_TAGS_DEFINED, "TODO,FIXME,??");
 		pStore.setDefault(PREF_MARKDOWN_COMMAND, MARKDOWNJ);
 		pStore.setDefault(PREF_SECTION_NUMBERS, true);
+		pStore.setDefault(PREF_GITHUB_SYNTAX, true);
 		
 		PreferenceConverter.setDefault(pStore, PREF_DEFUALT, DEF_DEFAULT);
 		PreferenceConverter.setDefault(pStore, PREF_COMMENT, DEF_COMMENT);
@@ -141,6 +144,16 @@ public class MarkdownPreferencePage
 
 		ColorFieldEditor codeBg = new ColorFieldEditor(PREF_CODE_BG, "Code Background", getFieldEditorParent());
 		addField(codeBg);
+		
+		/*
+		 * Fields for the preview window
+		 */
+
+		// Github Syntax support
+		fd = new BooleanFieldEditor(PREF_GITHUB_SYNTAX,
+				"Support Github Syntax",
+				getFieldEditorParent());
+		addField(fd);
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
This change does not support code highlighting but it
presents the code between '```' as a code block.
This syntax is not part of the original Markdown format. But it
allows to use this Eclipse plugin to preview Github code block.

Examples of Github code block:

---

```
function test() {
  console.log("notice the blank line before this function?");
}
```

---

---

``` javascript
var s = "JavaScript syntax highlighting";
alert(s);
```

---
