### PR TITLE
Add toolbar button to open the Markdown View directly from the Markdown

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -42,6 +42,21 @@
                style="push">
          </command>
       </menuContribution>
+      <menuContribution
+            allPopups="false"
+            locationURI="toolbar:org.eclipse.ui.main.toolbar?after=additions">
+         <toolbar
+               id="winterwell.markdown.MarkdownEditor">
+            <command
+                  commandId="winterwell.markdown.commands.OpenMdView"
+                  icon="icons/notepad.gif"
+                  style="push">
+               <visibleWhen
+                     checkEnabled="true">
+               </visibleWhen>
+            </command>
+         </toolbar>
+      </menuContribution>
    </extension>
    <extension
          point="org.eclipse.ui.commands">
@@ -49,6 +64,10 @@
             defaultHandler="winterwell.markdown.commands.OpenGfmView"
             id="winterwell.markdown.commands.OpenGfmView"
             name="Open GitHub Flavored Markdown View">
+      </command>
+      <command
+            id="winterwell.markdown.commands.OpenMdView"
+            name="Open Markdown View">
       </command>
       <command
             defaultHandler="winterwell.markdown.commands.Preferences"
@@ -120,6 +139,21 @@
                style="push">
          </action>
       </actionSet>
+   </extension>
+   <extension
+         point="org.eclipse.ui.handlers">
+      <handler
+            class="winterwell.markdown.commands.OpenMdView"
+            commandId="winterwell.markdown.commands.OpenMdView">
+         <activeWhen>
+            <with
+                  variable="activeEditorId">
+               <equals
+                     value="winterwell.markdown.editors.MarkdownEditor">
+               </equals>
+            </with>
+         </activeWhen>
+      </handler>
    </extension>
 
 </plugin>

--- a/plugin/src/winterwell/markdown/commands/OpenMdView.java
+++ b/plugin/src/winterwell/markdown/commands/OpenMdView.java
@@ -1,0 +1,39 @@
+package winterwell.markdown.commands;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+import winterwell.markdown.LogUtil;
+
+public class OpenMdView extends AbstractHandler {
+
+	@Override
+	public Object execute(final ExecutionEvent event) throws ExecutionException {
+		try {
+	        IWorkbenchPage activePage = HandlerUtil.getActiveWorkbenchWindow(event).getActivePage();
+	        String mdViewId = "winterwell.markdown.views.MarkdownPreview";
+	        IViewPart mdView = activePage.showView(mdViewId);
+	        activePage.activate(mdView);
+		} catch (PartInitException e) {
+			showError(e);
+	    } catch (Exception e) {
+	    	showError(e);
+	    }		
+		return null;
+	}
+
+	private void showError(Exception e) {
+		String title = "Exception while opening Markdown View";
+		String message = title+" (winterwell.markdown.views.MarkdownPreview)"
+				+"\nCheck Error Log View";
+		LogUtil.error(message, e);
+		MessageDialog.openError(Display.getDefault().getActiveShell(), title , message);
+	}
+}


### PR DESCRIPTION
Adds a button to the toolbar (only visible when the Markdown Editor is open) to open the Markdown View

This avoids navigating through all the available views in the "Show view" dialog, saving some clicks (Window -> Show views -> Other..., etc.).