### PR TITLE
Keep position of the preview Viewer

### DIFF
--- a/plugin/src/winterwell/markdown/editors/ActionBarContributor.java
+++ b/plugin/src/winterwell/markdown/editors/ActionBarContributor.java
@@ -22,10 +22,6 @@ public class ActionBarContributor extends TextEditorActionContributor {
 //	    	todo bars.setGlobalActionHandler(ActionFactory.PRINT.getId(), print);
 //	    	bars.updateActionBars();
 	    }
-	    // Update preview?
-		if (MarkdownPreview.preview != null) {
-			MarkdownPreview.preview.update();
-		}
 	}
 	public static IEditorPart getActiveEditor() {
 		return activeEditor;

--- a/plugin/src/winterwell/markdown/views/MarkdownPreview.java
+++ b/plugin/src/winterwell/markdown/views/MarkdownPreview.java
@@ -33,6 +33,9 @@ public class MarkdownPreview extends ViewPart {
 		@Override
 		public synchronized void run() {
 			try {
+				if (viewer == null || viewer.isDisposed()) {
+					return;
+				}
 				if (System.currentTimeMillis() - lastExecution < WAIT_TIME) {
 					return;
 				} else {
@@ -59,13 +62,10 @@ public class MarkdownPreview extends ViewPart {
 	
 	public static MarkdownPreview preview = null;
 	
-	private static File previewFile = null;
+	private File previewFile = null;
 	
-	private static Browser viewer = null;
+	private Browser viewer = null;
 
-	/**
-	 * The constructor.
-	 */
 	public MarkdownPreview() {
 		preview = this;
 		previewFile = Activator.getDefault().getStateLocation().append("markdown.html").toFile();
@@ -80,21 +80,22 @@ public class MarkdownPreview extends ViewPart {
 		viewer = new Browser(parent, SWT.MULTI); // | SWT.H_SCROLL | SWT.V_SCROLL
 	}
 
-
-
-
 	/**
 	 * Passing the focus request to the viewer's control.
 	 */
 	@Override
 	public void setFocus() {
-		if (viewer==null) return;
+		if (viewer == null || viewer.isDisposed()) {
+			return;
+		}
 		viewer.setFocus();
 		update();
 	}
 
 	public void update() {
-		if (viewer==null) return;
+		if (viewer == null || viewer.isDisposed()) {
+			return;
+		}
 		try {
 			IEditorPart editor = ActionBarContributor.getActiveEditor();
 			if (!(editor instanceof MarkdownEditor)) {
@@ -115,8 +116,9 @@ public class MarkdownPreview extends ViewPart {
 			// Smother
 			System.out.println(ex);
 			
-			if (viewer != null && !viewer.isDisposed())
+			if (viewer != null && !viewer.isDisposed()) {
 				viewer.setText(ex.getMessage());
+			}
 		}
 	}
 

--- a/plugin/src/winterwell/markdown/views/MarkdownPreview.java
+++ b/plugin/src/winterwell/markdown/views/MarkdownPreview.java
@@ -2,34 +2,73 @@ package winterwell.markdown.views;
 
 
 import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IPathEditorInput;
 import org.eclipse.ui.part.ViewPart;
 
+import winterwell.markdown.Activator;
 import winterwell.markdown.editors.ActionBarContributor;
 import winterwell.markdown.editors.MarkdownEditor;
 import winterwell.markdown.pagemodel.MarkdownPage;
+import winterwell.utils.io.FileUtils;
 
 
 
 
 public class MarkdownPreview extends ViewPart {
 	
+	private final Runnable refresh = new Runnable() {
+		volatile long lastExecution = System.currentTimeMillis();
+		final static long WAIT_TIME = 2000L;		
+
+		@Override
+		public synchronized void run() {
+			try {
+				if (System.currentTimeMillis() - lastExecution < WAIT_TIME) {
+					return;
+				} else {
+					lastExecution = System.currentTimeMillis();
+				}
+				URL fileUrl = previewFile.toURI().toURL();
+				URL oldUrl = null;
+				try {
+					oldUrl = new URL(viewer.getUrl());
+				} catch (MalformedURLException e) {
+					// Can happen, e.g. browser url is 'about:config'
+				}
+				if (fileUrl.equals(oldUrl)) {
+					viewer.refresh();
+				} else {
+					viewer.setUrl(fileUrl.toString());
+				}	
+			} catch (MalformedURLException e) {
+				// Should not happen since the URL is generated from a file
+				throw new RuntimeException(e); 
+			}
+		}
+	};
+	
 	public static MarkdownPreview preview = null;
 	
-	private Browser viewer = null;
+	private static File previewFile = null;
+	
+	private static Browser viewer = null;
 
 	/**
 	 * The constructor.
 	 */
 	public MarkdownPreview() {
 		preview = this;
+		previewFile = Activator.getDefault().getStateLocation().append("markdown.html").toFile();
 	}
 
 	/**
@@ -64,10 +103,14 @@ public class MarkdownPreview extends ViewPart {
 			}
 			MarkdownEditor ed = (MarkdownEditor) editor;
 			MarkdownPage page = ed.getMarkdownPage();
-			String html = page.html();
-			html = addBaseURL(editor, html);
-			if (page != null) viewer.setText(html);
-			else viewer.setText("");
+			if (page != null) {
+				String html = page.html();
+				html = addBaseURL(editor, html);
+				FileUtils.write(previewFile, html);
+				Display.getCurrent().asyncExec(refresh);
+			} else {
+				viewer.setText("");
+			}
 		} catch (Exception ex) {
 			// Smother
 			System.out.println(ex);


### PR DESCRIPTION
Change Preview Viewer refresh strategy:
* Preview Viewer uses an intermediate file, which enables the use of the `refresh()` method. The `refresh()`method does not reset the scroll position on every update of the viewer.
* Preview viewer is refreshed automatically after a small delay while the user types in the Markdown editor (and not when the editor regains focus).
* Old behaviour in which the preview viewer is refreshed when the View gains focus is maintained.