### PR TITLE
Improve error handling when GFM plugin is not found

### DIFF
--- a/plugin/src/winterwell/markdown/commands/OpenGfmView.java
+++ b/plugin/src/winterwell/markdown/commands/OpenGfmView.java
@@ -3,39 +3,55 @@ package winterwell.markdown.commands;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
+import org.osgi.framework.Bundle;
 
 import winterwell.markdown.LogUtil;
 
 public class OpenGfmView extends AbstractHandler {
 
+	private static final String GFM_VIEW_ID = "code.satyagraha.gfm.viewer.views.GfmView";
+	private static final String GFM_SYMBOLIC_NAME = "code.satyagraha.gfm.viewer.plugin";
+
 	@Override
 	public Object execute(final ExecutionEvent event) throws ExecutionException {
 		try {
-	        IWorkbenchPage activePage = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
-	        String gfmViewId = "code.satyagraha.gfm.viewer.views.GfmView";
-	        IViewPart gfmView = activePage.showView(gfmViewId);
-	        activePage.activate(gfmView);
+			Bundle gfmBundle = Platform.getBundle(GFM_SYMBOLIC_NAME);
+			if (gfmBundle == null) {
+				showInstallWarning();
+			} else {
+				IWorkbenchPage activePage = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+				IViewPart gfmView = activePage.showView(GFM_VIEW_ID);
+				activePage.activate(gfmView);
+			}
 		} catch (PartInitException e) {
 			showError(e);
-	    } catch (Exception e) {
-	    	showError(e);
-	    }		
+		} catch (Exception e) {
+			showError(e);
+		}
 		return null;
+	}
+
+	private void showInstallWarning() {
+		String title = "GFM viewer was not found";
+		String message = title + " (" + GFM_SYMBOLIC_NAME + ")"
+				+ "\n\nPlease ensure that you have correctly installed the plugin, see https://github.com/satyagraha/gfm_viewer";
+		MessageDialog.openWarning(Display.getDefault().getActiveShell(), title, message);
 	}
 
 	private void showError(Exception e) {
 		String title = "Exception while opening GitHub Flavored Markdown View";
-		String message = title+" (code.satyagraha.gfm.viewer.views.GfmView)"
-				+"\nCheck Error Log View and continue at https://github.com/winterstein/Eclipse-Markdown-Editor-Plugin/issues/42"
-				+"\n\nYou can also right-click file in Project Explorer"
-				+"\n and select \"Show in GFM view\".";
+		String message = title + " (" + GFM_VIEW_ID + ")"
+				+ "\nCheck Error Log View and continue at https://github.com/winterstein/Eclipse-Markdown-Editor-Plugin/issues/42"
+				+ "\n\nYou can also right-click file in Project Explorer"
+				+ "\n and select \"Show in GFM view\".";
 		LogUtil.error(message, e);
-		MessageDialog.openError(Display.getDefault().getActiveShell(), title , message);
+		MessageDialog.openError(Display.getDefault().getActiveShell(), title, message);
 	}
 }


### PR DESCRIPTION
See latest comments in #42.

Rather than opening an obscure error with a link to a GitHub issue, when the plugin detects that GFM Viewer is not installed it can display a more targeted warning suggesting to install it:

![gfm](https://user-images.githubusercontent.com/10694593/56866998-0a68bf00-69d8-11e9-81ca-75180127be23.jpg)
